### PR TITLE
Make the crate `no_std` compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ homepage = "https://github.com/polachok/liburing-sys"
 description = "raw bindings for liburing"
 
 [build-dependencies]
-bindgen = "0.49"
+bindgen = "0.51"
 cc = "1.0"
 
 [dependencies]
-libc = "0.2"
+libc = { version = "0.2", default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -40,6 +40,8 @@ fn main() {
     // to bindgen, and lets you build up options for
     // the resulting bindings.
     let bindings = bindgen::Builder::default()
+        .use_core()
+        .ctypes_prefix("libc")
         .clang_arg("-D_GNU_SOURCE")
         .whitelist_function("io_uring.*")
         .whitelist_function("_io_uring.*")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![no_std]
 
 use libc;
 
@@ -20,7 +21,7 @@ pub unsafe fn io_uring_prep_readv(
     nr_vecs: libc::c_uint,
     offset: libc::off_t,
 ) {
-    _io_uring_prep_readv(sqe, fd, std::mem::transmute(iovecs), nr_vecs, offset)
+    _io_uring_prep_readv(sqe, fd, core::mem::transmute(iovecs), nr_vecs, offset)
 }
 
 pub unsafe fn io_uring_prep_read_fixed(
@@ -40,7 +41,7 @@ pub unsafe fn io_uring_prep_writev(
     nr_vecs: libc::c_uint,
     offset: libc::off_t,
 ) {
-    _io_uring_prep_writev(sqe, fd, std::mem::transmute(iovecs), nr_vecs, offset)
+    _io_uring_prep_writev(sqe, fd, core::mem::transmute(iovecs), nr_vecs, offset)
 }
 
 pub unsafe fn io_uring_prep_write_fixed(


### PR DESCRIPTION
This makes the bindings useful for small programs that want to avoid linking to the standard libary, allocators, or panic handlers. You can read more about this [here](https://doc.rust-lang.org/1.1.0/book/no-stdlib.html).

This adds two new flags for bindgen:
* `use_core` enables the usage of the `core` crate, which can be thought of as a very reduced standard library that contains no operating system interaction.
* `ctypes_prefix("libc")` imports all c-types from the `libc` library instead of using the definitions that are re-exported within the standard library. These are both simply aliases for the number types with the corresponding sizes so completely equivalent.

The choice of `libc` is a minimal dependency insofar as we require `liburing` to perform the raw syscalls, for now, and it links to the c standard library anyways.